### PR TITLE
Let TextInput respect dataType prop correctly.

### DIFF
--- a/src/types/Text.jsx
+++ b/src/types/Text.jsx
@@ -7,7 +7,7 @@ var TextInput = React.createClass({
         inputClassName: Constants.inputClassName
     },
     render() {
-        var {onChange, onValueChange, onBlur, className,field,value, dataType, value, fieldAttrs, ...props} = this.props
+        var {onChange, onValueChange, onBlur, className, field, value, dataType, value, fieldAttrs, type, ...props} = this.props
         return <input ref="input" onBlur={this.handleValidate} onChange={this.handleChange} id={this.props.name}
                       className={css.forField(this)}
                       type={dataType || 'text'}


### PR DESCRIPTION
Fix a bug that the spreaded "type" prop overrides the dataType prop.